### PR TITLE
updated slick within hero to prevent flicker on page load

### DIFF
--- a/src/web/static/css/home.css
+++ b/src/web/static/css/home.css
@@ -113,6 +113,10 @@ body {
   -o-border-radius: 10px;
 }
 
+.slick-header {
+  display: none;
+}
+
 .btn.btn-action {
 	padding: 8px 15px;
 	margin: 5px;

--- a/src/web/templates/footer.html
+++ b/src/web/templates/footer.html
@@ -22,19 +22,18 @@
   {% block js %}{% endblock %}
   <script type="text/javascript">
     $(document).ready(function(){
-  $('.slick').slick({
-  slidesToShow: 1,
-  slidesToScroll: 1,
-  autoplay: true,
-  autoplaySpeed: 2000,
-  arrows: false,
-  fade: true,
-  });
-});
-
-        
-        
+      $('.slick').slick({
+        slidesToShow: 1,
+        slidesToScroll: 1,
+        autoplay: true,
+        autoplaySpeed: 2000,
+        arrows: false,
+        fade: true,
+      });
+    });
+    $('.slick-header').show();
   </script>
+
   <script type="text/javascript">
     $(document).ready(function(){
   $('.integrationslider').slick({
@@ -51,7 +50,7 @@
         slidesToShow: 3,
         slidesToScroll: 3,
         infinite: true,
-        dots: false 
+        dots: false
       }
     },
     {

--- a/src/web/templates/public/index.html
+++ b/src/web/templates/public/index.html
@@ -7,7 +7,7 @@
       Monitoring + Automated Remediation
     </h1>
     <h2 class="hero-explain">
-      <ul class="slick">
+      <ul class="slick slick-header">
       <li>If <b>HTTP: Keyword Search</b> is <b>False</b> then <b>CloudFlare: DNS Failover</b></li>
       <li>If <b>HTTP: GET</b> is <b>False</b> then <b>DigitalOcean: Reboot Server</b></li>
       <li>If <b>TCP: Port</b> is <b>True</b> then <b>CloudFlare: Add DNS Record</b></li>
@@ -140,7 +140,7 @@
 <!-- DIAGRAM SECTION -->
 <div class="section diagram-section">
   <div class="container">
-    
+
     <h2 class="subtitle">Integrated with the tools you already use</h2>
     <div class="integrationslider">
       <div><img src="/static/img/integrations/linode.png" class="img-responsive"></div>
@@ -224,7 +224,7 @@
     <div class="col-md-1">
     </div>
     </div>
-    
+
     <div class="row">
     <div class="col-md-1">
     </div>


### PR DESCRIPTION
on the page load, you see all of the text within the `<li>` for a few seconds before jQuery updates the dom. by now displaying the `<ul>` until after slick does it magic there is no longer a "flicker"
